### PR TITLE
fix(nuxt3): use latest edge channel without page prefetching

### DIFF
--- a/frameworks/nuxt3/package.json
+++ b/frameworks/nuxt3/package.json
@@ -12,6 +12,6 @@
     "highlight.js": "^11.6.0"
   },
   "devDependencies": {
-    "nuxt": "3.0.0-rc.6"
+    "nuxt": "npm:nuxt3@3.0.0-rc.8-27677607.a3a8706"
   }
 }


### PR DESCRIPTION
Following up https://twitter.com/steve8708/status/1558247170045751297?s=21&t=mNJZB79vPuhTTa_39hp3Rg this PR updates Nuxt 3 to [edge channel](https://v3.nuxtjs.org/guide/going-further/edge-channel) (containing latest RC.8 and also a recent commit that disables pages prefetching by default https://github.com/nuxt/framework/pull/6662)

I will follow up with subsequent PRs to improve testing measurements for Nuxt3 👍🏼 

Results with this PR on M2:

<img width="550" alt="image" src="https://user-images.githubusercontent.com/5158436/184919523-83f382e0-ff6f-4171-bbe9-a51ff5c44f68.png">


Screenshot I also [tweeted](https://twitter.com/_pi0_/status/1559559050341367809) by more optimizations using [`app.vue`](https://v3.nuxtjs.org/guide/directory-structure/app) instead of `pages/` and Nuxt 3 universal routing utils. It includes **more optimizations** than this PR.

<img width="570" alt="image" src="https://user-images.githubusercontent.com/5158436/184914758-363ce79a-b46d-4e5b-92fe-877cc7e57b5d.png">
