### PR TITLE
Make react-dom ssr section more accurate

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,29 +203,13 @@ SSR throughput of the dashboard page, measured by [autocannon](https://github.co
 
 Measure Node vs Bun vs Deno at SSR speed of a non trivial (the dashboard) React app. The below is requests per second. Larger numbers are better.
 
-##### Results using the same react-dom/server:
-
-```
-┌─────────┬──────────────────┬─────┬─────┬─────┬───────┬─────────┐
-│ (index) │       name       │ 1%  │ 50% │ 99% │  Avg  │ Std Dev │
-├─────────┼──────────────────┼─────┼─────┼─────┼───────┼─────────┤
-│    0    │ 'react-ssr-deno' │ 440 │ 550 │ 628 │  546  │  56.23  │
-│    1    │ 'react-ssr-bun'  │ 276 │ 386 │ 476 │ 391.9 │  57.61  │
-│    2    │ 'react-ssr-node' │ 328 │ 408 │ 420 │ 400.6 │  25.44  │
-└─────────┴──────────────────┴─────┴─────┴─────┴───────┴─────────┘
-```
-
-##### Results including Bun using a Bun-optimized react-dom/server
-
-In Bun's benchmarks they use a fork of react-dom/server optimized for Bun. This is the results of that:
-
 ```
 ┌─────────┬──────────────────┬─────┬─────┬─────┬───────┬─────────┐
 │ (index) │       name       │ 1%  │ 50% │ 99% │  Avg  │ Std Dev │
 ├─────────┼──────────────────┼─────┼─────┼─────┼───────┼─────────┤
 │    0    │ 'react-ssr-bun'  │ 598 │ 681 │ 737 │ 680.9 │  47.96  │
-│    1    │ 'react-ssr-deno' │ 460 │ 610 │ 660 │  591  │  69.64  │
-│    2    │ 'react-ssr-node' │ 340 │ 416 │ 430 │ 404.2 │  25.44  │
+│    1    │ 'react-ssr-deno' │ 440 │ 550 │ 628 │  546  │  56.23  │
+│    2    │ 'react-ssr-node' │ 328 │ 408 │ 420 │ 400.6 │  25.44  │
 └─────────┴──────────────────┴─────┴─────┴─────┴───────┴─────────┘
 ```
 


### PR DESCRIPTION
> ##### Results using the same react-dom/server:

None of the runtimes are using the same build of `react-dom/server`, so this line is incorrect. 

Node is using `react-dom/server.node`:
https://github.com/BuilderIO/framework-benchmarks/blob/2fb93ecf448737ab08b5e2efa481d54a709fce97/frameworks/react-ssr-node/http.jsx#L4

Deno is using `react-dom/server.browser`:
https://github.com/BuilderIO/framework-benchmarks/blob/2fb93ecf448737ab08b5e2efa481d54a709fce97/frameworks/react-ssr-deno/http.jsx#L5

Bun is using [what will become `react-dom/server.bun`](https://twitter.com/sebmarkbage/status/1560609478227030016):
https://github.com/BuilderIO/framework-benchmarks/blob/2fb93ecf448737ab08b5e2efa481d54a709fce97/frameworks/react-ssr-bun/http.js#L5



In real-world usage, it's not clear why someone would choose a build intended for a different host, so it's not particularly useful for benchmarking.

Also, we can switch bun's `import.meta.require` to be a regular `import` statement. There was a bug little while ago that has since been fixed

Are the tables manually updated? I just moved the bun row from the bottom table to the top table and removed the bottom table